### PR TITLE
.npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,5 +11,8 @@ config.gypi
 CVS
 npm-debug.log
 node_modules
+node_modules/
 android
 ios
+images/
+.github/


### PR DESCRIPTION
node_modules and images folders added to npm-ignore for package size and multiple react-native reference error.